### PR TITLE
'long vectors not supported yet' - Rf_length(x)

### DIFF
--- a/inst/include/RcppEigenWrap.h
+++ b/inst/include/RcppEigenWrap.h
@@ -159,7 +159,7 @@ namespace Rcpp{
         template <typename T, int RTYPE>
         class Eigen_Matrix_Exporter {
             public:
-            Eigen_Matrix_Exporter(SEXP x) : vec(x), d_ncol(1), d_nrow(Rf_length(x)) {
+            Eigen_Matrix_Exporter(SEXP x) : vec(x), d_ncol(1), d_nrow(Rf_xlength(x)) {
                 if (TYPEOF(x) != RTYPE)
                     throw std::invalid_argument("Wrong R type for mapped vector");
                 if (::Rf_isMatrix(x)) {
@@ -188,7 +188,7 @@ namespace Rcpp{
 
             T get() {
                 Shield<SEXP> dims( ::Rf_getAttrib( object, R_DimSymbol ) );
-                if( Rf_isNull(dims) || ::Rf_length(dims) != 2 ){
+                if( Rf_isNull(dims) || ::Rf_xlength(dims) != 2 ){
                     throw ::Rcpp::not_a_matrix();
                 }
                 int* dims_ = INTEGER(dims);
@@ -239,7 +239,7 @@ namespace Rcpp{
             int d_ncol, d_nrow ;
             
             public:
-            Exporter(SEXP x) : vec(x), d_ncol(1), d_nrow(Rf_length(x)) {
+            Exporter(SEXP x) : vec(x), d_ncol(1), d_nrow(Rf_xlength(x)) {
                 if (TYPEOF(x) != RTYPE)
                     throw std::invalid_argument("Wrong R type for mapped vector");
                 if (::Rf_isMatrix(x)) {
@@ -259,7 +259,7 @@ namespace Rcpp{
             int d_ncol, d_nrow ;
             
             public:
-            Exporter(SEXP x) : vec(x), d_ncol(1), d_nrow(Rf_length(x)) {
+            Exporter(SEXP x) : vec(x), d_ncol(1), d_nrow(Rf_xlength(x)) {
                 if (TYPEOF(x) != RTYPE)
                     throw std::invalid_argument("Wrong R type for mapped vector");
                 if (::Rf_isMatrix(x)) {


### PR DESCRIPTION
When declaring a Eigen::MapEigen::MatrixXd from a very big matrix,
I got a runtime error saying long vectors are not supported. 
I traced that back to the call 'Rf_length(x)' which is restricted to the pre- R 3.0.0
maximum length of vectors. 
I changed all calls of 'Rf_length(x)' to 'Rf_xlength(x)' which will use long vector support
if available. Both are declared in 'Rinterals.h' - lines 323-325

``` shell
# define XLENGTH(x) (IS_LONG_VEC(x) ? LONG_VEC_LENGTH(x) : SHORT_VEC_LENGTH(x))
# define XTRUELENGTH(x) (IS_LONG_VEC(x) ? LONG_VEC_TRUELENGTH(x) : SHORT_VEC_TRUELENGTH(x))
# define LENGTH(x) (IS_LONG_VEC(x) ? R_BadLongVector(x, __FILE__, __LINE__) : SHORT_VEC_LENGTH(x))
```

Of course that change would mean that the package depends R>=3.0.0 but Rcpp has that dependency anyways!

Best,

Claas Heuer
