### PR TITLE
Don't include R_ext/Lapack.h if MKL is used

### DIFF
--- a/src/fastLm.cpp
+++ b/src/fastLm.cpp
@@ -21,7 +21,9 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "fastLm.h"
+#if !defined(EIGEN_USE_MKL) // don't use R Lapack.h if MKL is enabled
 #include <R_ext/Lapack.h>
+#endif
 
 namespace lmsol {
     using Rcpp::_;


### PR DESCRIPTION
If Eigen is configured to use MKL, the inclusion of `R_ext/Lapack.h` results in incompatible declaration errors (R 3.2.0, GCC 5.1.0, MKL 11.0).