### PR TITLE
sync from Matrix 1.2-8 (*-9) inst/include/cholmod.h; Version++

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RcppEigen
 Type: Package
 Title: 'Rcpp' Integration for the 'Eigen' Templated Linear Algebra Library
-Version: 0.3.2.9.0
-Date: 2016-08-20
+Version: 0.3.2.9.1
+Date: 2017-03-13
 Author: Douglas Bates, Dirk Eddelbuettel, Romain Francois, and Yixuan Qiu;
  the authors of Eigen for the included version of Eigen
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/include/RcppEigenCholmod.h
+++ b/inst/include/RcppEigenCholmod.h
@@ -22,6 +22,16 @@
 #ifndef RcppEigen_CHOLMOD_H
 #define RcppEigen_CHOLMOD_H
 
+/* Original of this is Matrix/inst/include/cholmod.h --- sync with it (e.g for lme4) !
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+#include <stddef.h>
+#include <limits.h>
+
+// Rather use C99 -- which we require in R anyway
+#include <inttypes.h>
+
+
 #ifdef	__cplusplus
 extern "C" {
 #endif
@@ -29,19 +39,29 @@ extern "C" {
 // from Matrix/src/SuiteSparse_config/SuiteSparse_config.h - line 51 :
 #ifndef SuiteSparse_long
 
-#ifdef _WIN64
+/* #ifdef _WIN64 */
 
-#define SuiteSparse_long __int64
-#define SuiteSparse_long_max _I64_MAX
-#define SuiteSparse_long_idd "I64d"
+/* #define SuiteSparse_long __int64 */
+/* #define SuiteSparse_long_max _I64_MAX */
+/* #define SuiteSparse_long_idd "I64d" */
 
-#else
+/* #else */
 
-#define SuiteSparse_long long
-#define SuiteSparse_long_max LONG_MAX
-#define SuiteSparse_long_idd "ld"
+/* #define SuiteSparse_long long */
+/* #define SuiteSparse_long_max LONG_MAX */
+/* #define SuiteSparse_long_idd "ld" */
 
-#endif
+/* #endif */
+
+#define SuiteSparse_long int64_t
+    // typically long (but on WIN64)
+#define SuiteSparse_ulong uint64_t
+    //  only needed for ../COLAMD/Source/colamd.c (original has 'unsigned Int' which fails!!)
+#define SuiteSparse_long_max 9223372036854775801
+    // typically LONG_MAX (but ..)
+#define SuiteSparse_long_idd PRId64
+    // typically "ld"
+
 #define SuiteSparse_long_id "%" SuiteSparse_long_idd
 #endif
 
@@ -53,6 +73,7 @@ extern "C" {
 #define UF_long_idd SuiteSparse_long_idd
 #define UF_long_id  SuiteSparse_long_id
 #endif
+
 
 #define CHOLMOD_HAS_VERSION_FUNCTION
 
@@ -570,7 +591,7 @@ typedef struct cholmod_common_struct
      */
 
     size_t nrow ;	/* size of Flag and Head */
-    UF_long mark ;	/* mark value for Flag array */
+    SuiteSparse_long mark ;	/* mark value for Flag array */
     size_t iworksize ;	/* size of Iwork.  Upper bound: 6*nrow+ncol */
     size_t xworksize ;	/* size of Xwork,  in bytes.
 			 * maxrank*nrow*sizeof(double) for update/downdate.
@@ -595,7 +616,7 @@ typedef struct cholmod_common_struct
     void *Iwork ;	/* size iworksize, 2*nrow+ncol for most routines,
 			 * up to 6*nrow+ncol for cholmod_analyze. */
 
-    int itype ;		/* If CHOLMOD_LONG, Flag, Head, and Iwork are UF_long.
+    int itype ;		/* If CHOLMOD_LONG, Flag, Head, and Iwork are SuiteSparse_long.
 			 * Otherwise all three arrays are int. */
 
     int dtype ;		/* double or float */
@@ -660,8 +681,8 @@ typedef struct cholmod_common_struct
     double SPQR_small ;         /* task size is >= small */
 
     /* ---------------------------------------------------------------------- */
-    UF_long SPQR_istat [10] ;   /* for SuiteSparseQR statistics */
-    UF_long other2 [6] ;        /* reduced from size 16 in v1.6 */
+    SuiteSparse_long SPQR_istat [10] ;   /* for SuiteSparseQR statistics */
+    SuiteSparse_long other2 [6] ;        /* reduced from size 16 in v1.6 */
 
     /* ---------------------------------------------------------------------- */
     int other3 [10] ;       /* reduced from size 16 in v1.1. */
@@ -700,7 +721,7 @@ typedef struct cholmod_common_struct
 
 } cholmod_common ;
 
-// in ../../src/CHOLMOD/Include/cholmod_core.h  skip forward to - line 1114 :
+// in ../../src/CHOLMOD/Include/cholmod_core.h  skip forward to - line 1170 :
 /* A sparse matrix stored in compressed-column form. */
 
 typedef struct cholmod_sparse_struct
@@ -709,7 +730,7 @@ typedef struct cholmod_sparse_struct
     size_t ncol ;
     size_t nzmax ;	/* maximum number of entries in the matrix */
 
-    /* pointers to int or UF_long: */
+    /* pointers to int or SuiteSparse_long: */
     void *p ;		/* p [0..ncol], the column pointers */
     void *i ;		/* i [0..nzmax-1], the row indices */
 
@@ -742,8 +763,9 @@ typedef struct cholmod_sparse_struct
 	*/
 
     int itype ;		/* CHOLMOD_INT:     p, i, and nz are int.
-			 * CHOLMOD_INTLONG: p is UF_long, i and nz are int.
-			 * CHOLMOD_LONG:    p, i, and nz are UF_long.  */
+			 * CHOLMOD_INTLONG: p is SuiteSparse_long,
+			 *                  i and nz are int.
+			 * CHOLMOD_LONG:    p, i, and nz are SuiteSparse_long */
 
     int xtype ;		/* pattern, real, complex, or zomplex */
     int dtype ;		/* x and z are double or float */
@@ -753,7 +775,7 @@ typedef struct cholmod_sparse_struct
 
 } cholmod_sparse ;
 
-// in ../../src/CHOLMOD/Include/cholmod_core.h  skip forward to - line 1554 :
+// in ../../src/CHOLMOD/Include/cholmod_core.h  skip forward to - line 1552 :
 /* A symbolic and numeric factorization, either simplicial or supernodal.
  * In all cases, the row indices in the columns of L are kept sorted. */
 


### PR DESCRIPTION
For Matrix 1.2-8, I had updated the definition of `SparseSuite_long` in   `Matrix/inst/include/cholmod.h`,
see (the diffs) here:
https://r-forge.r-project.org/scm/viewvc.php/pkg/Matrix/inst/include/cholmod.h?root=matrix&r1=3040&r2=3200  to avoid problems with oldish / unusual compilers/platforms.... and to make it future proof, notably using 64 bit long on all platforms.
Now this lead to rare (and hard to trace) segmentation faults when using CRAN package `lme4` which uses both `RcppEigen` and classes from `Matrix`.... reported only in 32-bit Linux [here](https://github.com/lme4/lme4/issues/412).

What I found (also thanks to Brian Ripley who also found such problems on (32-bit) SPARC Solaris) is that indeed the file `inst/include/RcppEigenCholmod.h` has originally been a copy-paste-version of the file
`Matrix/inst/include/cholmod.h` (mentioned above)  made almost surely by Doug Bates (@dmbates).  And we all forgot that in the end, we use the "same" underlying mapping to Matrix' cholmod and hence must use compatible typedefs.... which we will have again after applying this pull request.

Of course, packages using `RcppEigen` __and__  which use this header should be recompiled after a new version of `RcppEigen` is made available on CRAN.
I hope Dirk (@eddelbuettel) can agree to submit that relatively soonish, so it is more or less synchronized with the upcoming new version of the Matrix package (1.2-9) and user would typically install both (when updating). 
Also, Matrix 1.2-9 is planned to be in R 3.4.0 (to appear in a bit more than a month I think).
