### PR TITLE
Update call to RcppArmadillo_fastLm_impl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_install:
   - ./run.sh bootstrap
 
 install:
-  - ./run.sh install_aptget r-cran-rcpp r-cran-matrix r-cran-inline r-cran-runit r-cran-pkgkitten
+  - ./run.sh install_aptget r-cran-rcpp r-cran-matrix r-cran-inline r-cran-runit r-cran-pkgkitten r-cran-microbenchmark
 
-script: 
+script:
   - ./run.sh run_tests
 
 #after_success:
@@ -28,4 +28,3 @@ notifications:
   email:
     on_success: change
     on_failure: change
-

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-05-30  Michael Weylandt  <michael.weylandt@gmail.com>
+
+	* inst/examples/lmBenchmark.R: Update call to RcppArmadillo's version
+	of fastLm in benchmark script
+
 2018-05-25  Ralf Stubner  <ralf.stubner@daqana.com>
 
 	* inst/include/RcppEigenWrap.h: Use Rf_xlength and R_xlen_t to

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,8 @@
 2018-05-30  Michael Weylandt  <michael.weylandt@gmail.com>
 
-	* inst/examples/lmBenchmark.R: Update call to RcppArmadillo's version
-	of fastLm in benchmark script
+	* inst/examples/lmBenchmark.R: Update benchmark script to use
+	microbenchmark and to use exposed fastLm functions from Rcpp
+	packages rather than invoking .Call directly
 
 2018-05-25  Ralf Stubner  <ralf.stubner@daqana.com>
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,6 @@ Depends: R (>= 2.15.1)
 LazyLoad: yes
 LinkingTo: Rcpp
 Imports: Matrix (>= 1.1-0), Rcpp (>= 0.11.0), stats, utils
-Suggests: inline, RUnit, pkgKitten
+Suggests: inline, RUnit, pkgKitten, microbenchmark
 URL: http://dirk.eddelbuettel.com/code/rcpp.eigen.html
 BugReports: https://github.com/RcppCore/RcppEigen/issues

--- a/inst/examples/lmBenchmark.R
+++ b/inst/examples/lmBenchmark.R
@@ -5,77 +5,78 @@
 ## This file is part of RcppEigen.
 
 require("stats", character=TRUE, quietly=TRUE)
-require("microbenchmark", character=TRUE, quietly=TRUE)
 require("RcppEigen", character=TRUE, quietly=TRUE)
 
-## define different versions of lm
-exprs <- list()
+if(require("microbenchmark", character=TRUE, quietly=TRUE)){
 
-## These versions use rank-revealing decompositions and thus can
-## handle rank-deficient cases.
+    ## define different versions of lm
+    exprs <- list()
 
-                                        # default version used in lm()
-exprs["lm.fit"] <- alist(stats::lm.fit(mm, y))
-                                        # versions from RcppEigen
-## column-pivoted QR decomposition - similar to lm.fit
-exprs["PivQR"] <- alist(RcppEigen::fastLmPure(mm, y, 0L))
-## LDLt Cholesky decomposition with rank detection
-exprs["LDLt"] <- alist(RcppEigen::fastLmPure(mm, y, 2L))
-## SVD using the Lapack subroutine dgesdd and Eigen support
-exprs["GESDD"] <- alist(RcppEigen::fastLmPure(mm, y, 6L))
-## SVD (the JacobiSVD class from Eigen)
-exprs["SVD"] <- alist(RcppEigen::fastLmPure(mm, y, 4L))
-## eigenvalues and eigenvectors of X'X
-exprs["SymmEig"] <- alist(RcppEigen::fastLmPure(mm, y, 5L))
+    ## These versions use rank-revealing decompositions and thus can
+    ## handle rank-deficient cases.
 
-## Non-rank-revealing decompositions.  These work fine except when
-## they don't.
+    # default version used in lm()
+    exprs["lm.fit"] <- alist(stats::lm.fit(mm, y))
 
-## Unpivoted  QR decomposition
-exprs["QR"] <- alist(RcppEigen::fastLmPure(mm, y, 1L))
-## LLt Cholesky decomposition
-exprs["LLt"] <- alist(RcppEigen::fastLmPure(mm, y, 3L))
+    # versions from RcppEigen
+    ## column-pivoted QR decomposition - similar to lm.fit
+    exprs["PivQR"] <- alist(RcppEigen::fastLmPure(mm, y, 0L))
+    ## LDLt Cholesky decomposition with rank detection
+    exprs["LDLt"] <- alist(RcppEigen::fastLmPure(mm, y, 2L))
+    ## SVD using the Lapack subroutine dgesdd and Eigen support
+    exprs["GESDD"] <- alist(RcppEigen::fastLmPure(mm, y, 6L))
+    ## SVD (the JacobiSVD class from Eigen)
+    exprs["SVD"] <- alist(RcppEigen::fastLmPure(mm, y, 4L))
+    ## eigenvalues and eigenvectors of X'X
+    exprs["SymmEig"] <- alist(RcppEigen::fastLmPure(mm, y, 5L))
 
-if (suppressMessages(require("RcppArmadillo", character=TRUE, quietly=TRUE))) {
-    exprs["arma"] <- alist(RcppArmadillo::fastLmPure(mm, y))
+    ## Non-rank-revealing decompositions.  These work fine except when
+    ## they don't.
+
+    ## Unpivoted  QR decomposition
+    exprs["QR"] <- alist(RcppEigen::fastLmPure(mm, y, 1L))
+    ## LLt Cholesky decomposition
+    exprs["LLt"] <- alist(RcppEigen::fastLmPure(mm, y, 3L))
+
+    if (suppressMessages(require("RcppArmadillo", character=TRUE, quietly=TRUE))) {
+        exprs["arma"] <- alist(RcppArmadillo::fastLmPure(mm, y))
+    }
+
+    if (suppressMessages(require("RcppGSL", character=TRUE, quietly=TRUE))) {
+        exprs["GSL"] <- alist(RcppGSL::fastLmPure(mm, y))
+    }
+
+    do_bench <- function(n=100000L, p=40L, nrep=20L, suppressSVD=(n > 100000L)) {
+        mm <- cbind(1, matrix(rnorm(n * (p - 1L)), nc=p-1L))
+        y <- rnorm(n)
+        if (suppressSVD) exprs <- exprs[!names(exprs) %in% c("SVD", "GSL")]
+
+        cat("lm benchmark for n = ", n, " and p = ", p, ": nrep = ", nrep, "\n", sep='')
+        cat("RcppEigen: Included Eigen version", paste(RcppEigen:::eigen_version(FALSE), collapse="."), "\n")
+        cat("RcppEigen: Eigen SSE support", RcppEigen:::Eigen_SSE(), "\n")
+
+        mb <- microbenchmark(list=exprs, times = nrep)
+
+        op <- options(microbenchmark.unit="relative")
+        on.exit(options(op))
+
+        mb_relative <- summary(mb)
+        levels(mb_relative$expr) <- names(exprs)
+
+        options(microbenchmark.unit=NULL)
+        mb_absolute <- summary(mb)
+        levels(mb_absolute$expr) <- names(exprs)
+
+        mb_combined <- merge(mb_relative[, c("expr", "median")],
+                             mb_absolute[, c("expr", "median")],
+                             by="expr")
+
+        colnames(mb_combined) <- c("Method",
+                                   "Relative",
+                                   paste0("Elapsed (", attr(mb_absolute, "unit"), ")"))
+
+        mb_combined[order(mb_combined$Relative),]
+    }
+
+    print(do_bench())
 }
-
-if (suppressMessages(require("RcppGSL", character=TRUE, quietly=TRUE))) {
-    exprs["GSL"] <- alist(RcppGSL::fastLmPure(mm, y))
-}
-
-do_bench <- function(n=100000L, p=40L, nrep=20L, suppressSVD=(n > 100000L)) {
-    mm <- cbind(1, matrix(rnorm(n * (p - 1L)), nc=p-1L))
-    y <- rnorm(n)
-    if (suppressSVD) exprs <- exprs[!names(exprs) %in% c("SVD", "GSL")]
-    cat("lm benchmark for n = ", n, " and p = ", p, ": nrep = ", nrep, "\n", sep='')
-    mb <- microbenchmark(list=exprs, times = nrep)
-    
-    op <- options(microbenchmark.unit="relative")
-    on.exit(options(op))
-    
-    mb_relative <- summary(mb)
-    levels(mb_relative$expr) <- names(exprs)
-    
-    options(microbenchmark.unit=NULL)
-    mb_absolute <- summary(mb)
-    levels(mb_absolute$expr) <- names(exprs)
-
-    mb_combined <- merge(mb_relative[, c("expr", "median")], 
-                         mb_absolute[, c("expr", "median")], 
-                         by="expr")
-    
-    colnames(mb_combined) <- c("Method", 
-                               "Relative", 
-                               paste0("Elapsed (", attr(mb_absolute, "unit"), ")"))
-    
-    mb_combined[order(mb_combined$Relative),]
-}
-
-print(do_bench())
-
-sessionInfo()
-
-.Call("RcppEigen_eigen_version", FALSE, PACKAGE="RcppEigen")
-
-.Call("RcppEigen_Eigen_SSE", PACKAGE="RcppEigen")

--- a/inst/examples/lmBenchmark.R
+++ b/inst/examples/lmBenchmark.R
@@ -5,7 +5,7 @@
 ## This file is part of RcppEigen.
 
 require("stats", character=TRUE, quietly=TRUE)
-require("rbenchmark", character=TRUE, quietly=TRUE)
+require("microbenchmark", character=TRUE, quietly=TRUE)
 require("RcppEigen", character=TRUE, quietly=TRUE)
 
 ## define different versions of lm
@@ -15,33 +15,33 @@ exprs <- list()
 ## handle rank-deficient cases.
 
                                         # default version used in lm()
-exprs$lm.fit <- expression(stats::lm.fit(mm, y))
+exprs["lm.fit"] <- alist(stats::lm.fit(mm, y))
                                         # versions from RcppEigen
 ## column-pivoted QR decomposition - similar to lm.fit
-exprs$PivQR <- expression(.Call("RcppEigen_fastLm_Impl", mm, y, 0L, PACKAGE="RcppEigen"))
+exprs["PivQR"] <- alist(RcppEigen::fastLmPure(mm, y, 0L))
 ## LDLt Cholesky decomposition with rank detection
-exprs$LDLt <- expression(.Call("RcppEigen_fastLm_Impl", mm, y, 2L, PACKAGE="RcppEigen"))
+exprs["LDLt"] <- alist(RcppEigen::fastLmPure(mm, y, 2L))
 ## SVD using the Lapack subroutine dgesdd and Eigen support
-exprs$GESDD <- expression(.Call("RcppEigen_fastLm_Impl", mm, y, 6L, PACKAGE="RcppEigen"))
+exprs["GESDD"] <- alist(RcppEigen::fastLmPure(mm, y, 6L))
 ## SVD (the JacobiSVD class from Eigen)
-exprs$SVD <- expression(.Call("RcppEigen_fastLm_Impl", mm, y, 4L, PACKAGE="RcppEigen"))
+exprs["SVD"] <- alist(RcppEigen::fastLmPure(mm, y, 4L))
 ## eigenvalues and eigenvectors of X'X
-exprs$SymmEig <- expression(.Call("RcppEigen_fastLm_Impl", mm, y, 5L, PACKAGE="RcppEigen"))
+exprs["SymmEig"] <- alist(RcppEigen::fastLmPure(mm, y, 5L))
 
 ## Non-rank-revealing decompositions.  These work fine except when
 ## they don't.
 
 ## Unpivoted  QR decomposition
-exprs$QR <- expression(.Call("RcppEigen_fastLm_Impl", mm, y, 1L, PACKAGE="RcppEigen"))
+exprs["QR"] <- alist(RcppEigen::fastLmPure(mm, y, 1L))
 ## LLt Cholesky decomposition
-exprs$LLt <- expression(.Call("RcppEigen_fastLm_Impl", mm, y, 3L, PACKAGE="RcppEigen"))
+exprs["LLt"] <- alist(RcppEigen::fastLmPure(mm, y, 3L))
 
 if (suppressMessages(require("RcppArmadillo", character=TRUE, quietly=TRUE))) {
-    exprs$arma <- expression(.Call("_RcppArmadillo_fastLm_impl", mm, y, PACKAGE="RcppArmadillo"))
+    exprs["arma"] <- alist(RcppArmadillo::fastLmPure(mm, y))
 }
 
 if (suppressMessages(require("RcppGSL", character=TRUE, quietly=TRUE))) {
-    exprs$GSL <- expression(.Call("RcppGSL_fastLm", mm, y, PACKAGE="RcppGSL"))
+    exprs["GSL"] <- alist(RcppGSL::fastLmPure(mm, y))
 }
 
 do_bench <- function(n=100000L, p=40L, nrep=20L, suppressSVD=(n > 100000L)) {
@@ -49,11 +49,27 @@ do_bench <- function(n=100000L, p=40L, nrep=20L, suppressSVD=(n > 100000L)) {
     y <- rnorm(n)
     if (suppressSVD) exprs <- exprs[!names(exprs) %in% c("SVD", "GSL")]
     cat("lm benchmark for n = ", n, " and p = ", p, ": nrep = ", nrep, "\n", sep='')
-    do.call(benchmark, c(exprs,
-                         list(order="relative",
-                              columns = c("test", "relative",
-                              "elapsed", "user.self", "sys.self"),
-                              replications = nrep)))
+    mb <- microbenchmark(list=exprs, times = nrep)
+    
+    op <- options(microbenchmark.unit="relative")
+    on.exit(options(op))
+    
+    mb_relative <- summary(mb)
+    levels(mb_relative$expr) <- names(exprs)
+    
+    options(microbenchmark.unit=NULL)
+    mb_absolute <- summary(mb)
+    levels(mb_absolute$expr) <- names(exprs)
+
+    mb_combined <- merge(mb_relative[, c("expr", "median")], 
+                         mb_absolute[, c("expr", "median")], 
+                         by="expr")
+    
+    colnames(mb_combined) <- c("Method", 
+                               "Relative", 
+                               paste0("Elapsed (", attr(mb_absolute, "unit"), ")"))
+    
+    mb_combined[order(mb_combined$Relative),]
 }
 
 print(do_bench())

--- a/inst/examples/lmBenchmark.R
+++ b/inst/examples/lmBenchmark.R
@@ -37,7 +37,7 @@ exprs$QR <- expression(.Call("RcppEigen_fastLm_Impl", mm, y, 1L, PACKAGE="RcppEi
 exprs$LLt <- expression(.Call("RcppEigen_fastLm_Impl", mm, y, 3L, PACKAGE="RcppEigen"))
 
 if (suppressMessages(require("RcppArmadillo", character=TRUE, quietly=TRUE))) {
-    exprs$arma <- expression(.Call("RcppArmadillo_fastLm", mm, y, PACKAGE="RcppArmadillo"))
+    exprs$arma <- expression(.Call("_RcppArmadillo_fastLm_impl", mm, y, PACKAGE="RcppArmadillo"))
 }
 
 if (suppressMessages(require("RcppGSL", character=TRUE, quietly=TRUE))) {


### PR DESCRIPTION
The RcppEigen benchmark script calls a C++ function which is no longer provided by RcppArmadillo (since mid-August 2017). This updates the benchmark script to call the RcppAttributes-generated entry point `_RcppArmadillo_fastLm_impl`

```
$ R
The following objects are masked from package:base:

    F, pi, T

> # Before
> source("https://raw.githubusercontent.com/RcppCore/RcppEigen/master/inst/examples/lmBenchmark.R")
lm benchmark for n = 100000 and p = 40: nrep = 20
Error in .Call("RcppArmadillo_fastLm", mm, y, PACKAGE = "RcppArmadillo") :
  "RcppArmadillo_fastLm" not available for .Call() for package "RcppArmadillo"
Timing stopped at: 0.002 0 0.001

> # After
> source("https://raw.githubusercontent.com/michaelweylandt/RcppEigen/mw/update_armadillo_call_in_lmBenchmark/inst/examples/lmBenchmark.R")
lm benchmark for n = 100000 and p = 40: nrep = 20
      test relative elapsed user.self sys.self
3     LDLt    1.000   0.321     0.320    0.000
8      LLt    1.012   0.325     0.325    0.000
6  SymmEig    2.246   0.721     0.715    0.006
7       QR    7.255   2.329     2.329    0.000
2    PivQR    7.695   2.470     2.463    0.000
1   lm.fit   13.838   4.442     4.434    0.007
9     arma   18.209   5.845     5.843    0.000
4    GESDD   31.931  10.250    10.221    0.023
5      SVD   56.106  18.010    17.743    0.266
10     GSL  115.374  37.035    36.920    0.112
```
