### PR TITLE
Fix package skeleton creation import listing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-02-16  James Joseph Balamuta <balamut2@illinois.edu>
+
+	* R/runit.RcppEigen.R: Removed listing RcppEigen in Imports during
+	skeleton package creation.
+
 2018-11-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.3.3.5.0

--- a/R/RcppEigen.package.skeleton.R
+++ b/R/RcppEigen.package.skeleton.R
@@ -64,12 +64,11 @@ RcppEigen.package.skeleton <- function(name= "anRpackage", list = character(),
     DESCRIPTION <- file.path(root, "DESCRIPTION")
     if (file.exists(DESCRIPTION)) {
         x <- cbind(read.dcf(DESCRIPTION), 
-                   "Imports" = sprintf("Rcpp (>= %s), RcppEigen (>= %s)", 
-                   packageDescription("Rcpp")[["Version"]], 
-                   packageDescription("RcppEigen")[["Version"]]), 
+                   "Imports" = sprintf("Rcpp (>= %s)", 
+                   packageDescription("Rcpp")[["Version"]]), 
                    "LinkingTo" = "Rcpp, RcppEigen")
         write.dcf(x, file = DESCRIPTION)
-        message(" >> added Imports: Rcpp, RcppEigen")
+        message(" >> added Imports: Rcpp")
         message(" >> added LinkingTo: Rcpp, RcppEigen")
     }
 	

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,13 @@
 \newcommand{\ghpr}{\href{https://github.com/RcppCore/RcppEigen/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/RcppCore/RcppEigen/issues/#1}{##1}}
 
+\section{Changes in RcppEigen version 0.3.3.?.0 (2019-??-??)}{
+  \itemize{
+    \item Fixed skeleton package creation listing RcppEigen under Imports
+    (James Balamuta in \ghpr{68} addressing \ghit{16}).
+  }
+}
+
 \section{Changes in RcppEigen version 0.3.3.5.0 (2018-11-24)}{
   \itemize{
     \item Updated to version 3.3.5 of Eigen (Dirk in \ghpr{65})


### PR DESCRIPTION
Remove Imports listing of RcppEigen when using the package skeleton creation helper.

Related to left over issue from #16 