### PR TITLE
Patch integer overflow in 'Rcpp::wrap(<Eigen::Matrix>)'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-01-15  Mikael Jagan  <jaganmn@mcmaster.ca>
+
+	* inst/include/RcppEigenWrap.h: Use R_xlen_t for vectors rows + cols
+
 2021-12-29  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Add total downloads badge

--- a/inst/include/RcppEigenWrap.h
+++ b/inst/include/RcppEigenWrap.h
@@ -2,7 +2,7 @@
 //
 // RcppEigenWrap.h: Rcpp wrap methods for Eigen matrices, vectors and arrays
 //
-// Copyright (C) 2011 - 2012   Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2011 - 2022   Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of RcppEigen.
 //
@@ -81,18 +81,18 @@ namespace Rcpp{
         // for plain dense objects
         template <typename T>
         SEXP eigen_wrap_plain_dense( const T& obj, Rcpp::traits::true_type ) {
-	    typename Eigen::internal::conditional<
-		T::IsRowMajor,
-		Eigen::Matrix<typename T::Scalar,
-			      T::RowsAtCompileTime,
-			      T::ColsAtCompileTime>,
-		const T&>::type objCopy(obj);
-	    R_xlen_t m = obj.rows(), n = obj.cols(), size = m * n;
-	    SEXP ans = PROTECT(::Rcpp::wrap(objCopy.data(), objCopy.data() + size));
+            typename Eigen::internal::conditional<
+                T::IsRowMajor,
+                Eigen::Matrix<typename T::Scalar,
+                              T::RowsAtCompileTime,
+                              T::ColsAtCompileTime>,
+                const T&>::type objCopy(obj);
+            R_xlen_t m = obj.rows(), n = obj.cols(), size = m * n;
+            SEXP ans = PROTECT(::Rcpp::wrap(objCopy.data(), objCopy.data() + size));
             if ( T::ColsAtCompileTime != 1 ) {
-		if (m > INT_MAX || n > INT_MAX) {
-		    throw std::runtime_error("array dimensions cannot exceed INT_MAX");
-		}
+                if (m > INT_MAX || n > INT_MAX) {
+                    Rcpp::stop("array dimensions cannot exceed INT_MAX");
+                }
                 SEXP dd = PROTECT(::Rf_allocVector(INTSXP, 2));
                 int *d = INTEGER(dd);
                 d[0] = m;


### PR DESCRIPTION
Fixes integer overflow bug detected [here](https://stackoverflow.com/questions/70714510) so that `Rcpp::wrap(<Eigen::Matrix>)` actually supports long vectors.