### PR TITLE
Do not throw INT_MAX error when returning vector

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,11 +1,17 @@
-coverage:
-  precision: 1
-
 comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: 70%    # the (on purpose low) required coverage value
+        threshold: 2%  # the permitted delta in hitting the target
+    patch:
+      default:
+        target: 0%     # the (on purpose low) required coverage value
 
-ignore:
-  - "inst/include/Eigen/"
-  - "inst/include/unsupported/Eigen/"
-
-codecov:
-  token: 0b726434-b483-4a82-9cfe-e8312f3b3e9b
+#  layout: "header, diff, tree, changes"
+#  behavior: default
+#  require_changes: false  # if true: only post the comment if coverage changes
+#  branches: null
+#  flags: null
+#  paths: null

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2022-01-16  Dirk Eddelbuettel  <edd@debian.org>
+
+	* .codecov.yml: Added to not trigger PR fail for small additions
+
+2022-01-16  Mikael Jagan  <jaganmn@mcmaster.ca>
+
+	* inst/include/RcppEigenWrap.h: Refine use plain dense wrap() change
+
 2022-01-15  Mikael Jagan  <jaganmn@mcmaster.ca>
 
 	* inst/include/RcppEigenWrap.h: Use R_xlen_t for vectors rows + cols


### PR DESCRIPTION
Continuing from PR #105, fixing a bug introduced in https://github.com/RcppCore/RcppEigen/commit/f82ac81067c2ada51752f79b5c0fa8000396d0ad. `wrap` checked for dimensions exceeding `INT_MAX` even when the return value was a vector without dimensions. Unit test from other PR caught it.