### PR TITLE
adapt preprocessor defines for result_of/invoke_result

### DIFF
--- a/inst/include/Eigen/src/Core/util/Macros.h
+++ b/inst/include/Eigen/src/Core/util/Macros.h
@@ -387,6 +387,30 @@
   #define EIGEN_HAS_C99_MATH 0
 #endif
 #endif
+  
+/// \internal EIGEN_COMP_MSVC_LANG set to _MSVC_LANG if the compiler is Microsoft Visual C++, 0 otherwise.
+#if defined(_MSVC_LANG)
+#define EIGEN_COMP_MSVC_LANG _MSVC_LANG
+#else
+#define EIGEN_COMP_MSVC_LANG 0
+#endif
+  
+// The macro EIGEN_CPLUSPLUS is a replacement for __cplusplus/_MSVC_LANG that
+// works for both platforms, indicating the C++ standard version number.
+//
+// With MSVC, without defining /Zc:__cplusplus, the __cplusplus macro will
+// report 199711L regardless of the language standard specified via /std.
+// We need to rely on _MSVC_LANG instead, which is only available after
+// VS2015.3.
+#if EIGEN_COMP_MSVC_LANG > 0
+#define EIGEN_CPLUSPLUS EIGEN_COMP_MSVC_LANG
+#elif EIGEN_COMP_MSVC >= 1900
+#define EIGEN_CPLUSPLUS 201103L
+#elif defined(__cplusplus)
+#define EIGEN_CPLUSPLUS __cplusplus
+#else
+#define EIGEN_CPLUSPLUS 0
+#endif
 
 // Does the compiler support result_of?
 // result_of was deprecated in c++17 and removed in c++ 20
@@ -401,7 +425,7 @@
 // Does the compiler support invoke_result?
 // invoke_result was introduced in c++17
 #ifndef EIGEN_HAS_STD_INVOKE_RESULT
-#if EIGEN_COMP_CXXVER > 201402L
+#if EIGEN_CPLUSPLUS > 201402L
 #define EIGEN_HAS_STD_INVOKE_RESULT 1
 #else
 #define EIGEN_HAS_STD_INVOKE_RESULT 0

--- a/inst/include/Eigen/src/Core/util/Macros.h
+++ b/inst/include/Eigen/src/Core/util/Macros.h
@@ -389,11 +389,22 @@
 #endif
 
 // Does the compiler support result_of?
+// result_of was deprecated in c++17 and removed in c++ 20
 #ifndef EIGEN_HAS_STD_RESULT_OF
-#if EIGEN_MAX_CPP_VER>=11 && ((__has_feature(cxx_lambdas) || (defined(__cplusplus) && __cplusplus >= 201103L)))
+#if EIGEN_HAS_CXX11 && EIGEN_CPLUSPLUS <= 201402L
 #define EIGEN_HAS_STD_RESULT_OF 1
 #else
 #define EIGEN_HAS_STD_RESULT_OF 0
+#endif
+#endif
+
+// Does the compiler support invoke_result?
+// invoke_result was introduced in c++17
+#ifndef EIGEN_HAS_STD_INVOKE_RESULT
+#if EIGEN_COMP_CXXVER > 201402L
+#define EIGEN_HAS_STD_INVOKE_RESULT 1
+#else
+#define EIGEN_HAS_STD_INVOKE_RESULT 0
 #endif
 #endif
 

--- a/inst/include/Eigen/src/Core/util/Meta.h
+++ b/inst/include/Eigen/src/Core/util/Meta.h
@@ -309,19 +309,36 @@ protected:
 };
 
 /** \internal
-  * Convenient struct to get the result type of a unary or binary functor.
-  *
-  * It supports both the current STL mechanism (using the result_type member) as well as
-  * upcoming next STL generation (using a templated result member).
-  * If none of these members is provided, then the type of the first argument is returned. FIXME, that behavior is a pretty bad hack.
-  */
-#if EIGEN_HAS_STD_RESULT_OF
+ * Convenient struct to get the result type of a nullary, unary, binary, or
+ * ternary functor.
+ * 
+ * Pre C++11:
+ * Supports both a Func::result_type member and templated
+ * Func::result<Func(ArgTypes...)>::type member.
+ * 
+ * If none of these members is provided, then the type of the first
+ * argument is returned.
+ * 
+ * Post C++11:
+ * This uses std::result_of. However, note the `type` member removes
+ * const and converts references/pointers to their corresponding value type.
+ */
+#if EIGEN_HAS_STD_INVOKE_RESULT
+template<typename T> struct result_of;
+
+template<typename F, typename... ArgTypes>
+struct result_of<F(ArgTypes...)> {
+  typedef typename std::invoke_result<F, ArgTypes...>::type type1;
+  typedef typename remove_all<type1>::type type;
+};
+#elif EIGEN_HAS_STD_RESULT_OF
 template<typename T> struct result_of {
   typedef typename std::result_of<T>::type type1;
   typedef typename remove_all<type1>::type type;
 };
 #else
 template<typename T> struct result_of { };
+
 
 struct has_none {int a[1];};
 struct has_std_result_type {int a[2];};


### PR DESCRIPTION
Regarding #123: I don't really have the capacity to work on the Eigen 3.4.0 update, but I thought adapting the relevant parts ([1](https://gitlab.com/libeigen/eigen/-/blob/3.4/Eigen/src/Core/util/Macros.h?ref_type=heads#L698), [2](https://gitlab.com/libeigen/eigen/-/blob/3.4/Eigen/src/Core/util/Macros.h?ref_type=heads#L717), [3](https://gitlab.com/libeigen/eigen/-/blob/3.4/Eigen/src/Core/util/Meta.h?ref_type=heads#L502])) of the preprocessor logic could be an easy fix to make the warnings disappear (and ensure RcppEigen compiles with C++20)?

