### PR TITLE
Tweak to build with clang on Windows.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-02-12  Tomas Kalibera  <tomas.kalibera@gmail.com>
+
+	* inst/include/unsupported/Eigen/CXX11/src/ThreadPool/ThreadYield.h:
+	Support clang on Windows by including 'sched.h' header
+
 2023-11-01  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): CRAN Release 0.3.3.9.4

--- a/inst/include/unsupported/Eigen/CXX11/src/ThreadPool/ThreadYield.h
+++ b/inst/include/unsupported/Eigen/CXX11/src/ThreadPool/ThreadYield.h
@@ -12,6 +12,7 @@
 
 // Try to come up with a portable way to yield
 #if EIGEN_COMP_GNUC && EIGEN_GNUC_AT_MOST(4, 7)
+#include <sched.h>
 #define EIGEN_THREAD_YIELD() sched_yield()
 #else
 #define EIGEN_THREAD_YIELD() std::this_thread::yield()


### PR DESCRIPTION
Without this fix, e.g. DAISIE fails to build on clang/Windows due to undefined symbol sched_yield().

I am seeing this with LLVM 17, where clang identifies as gcc 4.2. I think ideally the ifdef should be changed so that modern clang also uses the C++ version - I see on godbolt that clang 6.0.0 should be good enough, but I am not sure how to portably check the "clang" way.