### PR TITLE
Update link to Eigen website

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ### Synopsis
 
-[Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page) is a C++ template library for linear algebra:
+[Eigen](https://libeigen.gitlab.io/) is a C++ template library for linear algebra:
 matrices, vectors, numerical solvers and related algorithms.  It supports dense and sparse
 matrices on integer, floating point and complex numbers, decompositions of such matrices,
 and solutions of linear systems. Its performance on many algorithms is comparable with


### PR DESCRIPTION
The current link appears dead (404):

https://libeigen.gitlab.io/index.php?title=Main_Page

<img width="510" height="172" alt="Screenshot of text 'Oops! This page doesn't exist. Try going back to the [home page](https://libeigen.gitlab.io/).'" src="https://github.com/user-attachments/assets/1279e656-1288-4516-906c-eda4c4d00f7e" />

I've replaced it with the 'home page' link suggested.